### PR TITLE
Blocks: add animated textures + fix texture scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Please visit his personal website for other cool projects: https://jamesfator.co
 
 ## TODO
 
+* Fix grass edge on l1136
 * Rename: init_sprites => init_graphics?
 * Manage the limits in mesh as well?
   => See level 1136 (Green Hill Zone Act 2) to align checkerboard and scale.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Please visit his personal website for other cool projects: https://jamesfator.co
 ## TODO
 
 * Fix grass edge on l1136
+* Shouldn't `assets.get_url(texture_name)` be `assets.get_url(texture_file)`?
+* Attach texture_params directly to blocks, entities etc? Instead of adding the params one by one?
 * Rename: init_sprites => init_graphics?
 * Manage the limits in mesh as well?
   => See level 1136 (Green Hill Zone Act 2) to align checkerboard and scale.

--- a/README.md
+++ b/README.md
@@ -103,15 +103,18 @@ Please visit his personal website for other cool projects: https://jamesfator.co
 
 ## TODO
 
-* On l7388, scale and direction of layer textures is wrong (look clouds!)
-* Animated textures for blocks/edges? (l8682/l7388)
+* Rename: init_sprites => init_graphics?
+* Manage the limits in mesh as well?
+  => See level 1136 (Green Hill Zone Act 2) to align checkerboard and scale.
+* Animated textures for blocks/edges? (l8682/l7388) 
+  => performance.now(), Date.now() or Ticker?
 * Manage sky better: 
   * `<sky color_r="150" color_g="100" color_b="50" zoom="3.0">sky1</sky>`
   * `<sky color_g="255" zoom="3.7" color_a="255" color_b="255" offset="0.16" drifted="false" use_params="true" color_r="255">Water1</sky>`
   * http://wiki.xmoto.tuxfamily.org/index.php?title=Others_tips_to_make_levels
-* Manage Sprites better
-  * http://wiki.xmoto.tuxfamily.org/index.php?title=Others_tips_to_make_levels (at the end)
-  * => Still need to adapt aabb if rotation (just increase the size, don't try to rotate)
+* Adjust a bit the camera (player more on the borders of the camera, less zoom)
+* Sounds with PixiJS Sound and play on the left/right depending on position
+* Adjust the height of the driver (less bumpy!? Height of sprite? Compare values?)
 * Manage checkpoints
   * http://wiki.xmoto.tuxfamily.org/index.php?title=Notes_on_Checkpoints
 * Parse maps from https://github.com/bjorn/tiled ?

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1462,13 +1462,17 @@
     // later swap mesh.texture between frame textures; static blocks just keep
     // their single texture.
 
-    // UV per world unit = scale * 0.25, matching xmoto C++
-    // (src/xmscene/Block.cpp: texturePos = world * scale * 0.25). Combined with
-    // the source's 'repeat' wrap, the texture tiles every 4 world units at
-    // scale=1, independently of texture pixel size.
+    // UV per world unit = scale * 0.25 * (256 / source.width).
+    // xmoto C++ uses scale * 0.25 directly (src/xmscene/Block.cpp:
+    // texturePos = world * scale * 0.25), which assumes 256-pixel textures and
+    // stretches lower-resolution textures (e.g. 128px clouds/water). Anchoring
+    // on 256 keeps standard-size textures identical to xmoto while tiling
+    // smaller textures proportionally denser for consistent on-screen pixel
+    // density.
     build_mesh(block) {
-      var geometry, i, indices, k, len, point, positions, ref, uv_scale, uvs;
-      uv_scale = 0.25 * block.usetexture.scale;
+      var geometry, i, indices, k, len, point, positions, ref, source, uv_scale, uvs;
+      source = block.textures[0].source;
+      uv_scale = block.usetexture.scale * 64.0 / source.width;
       positions = new Float32Array(block.points.length * 2);
       uvs = new Float32Array(block.points.length * 2);
       ref = block.points;

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1274,7 +1274,7 @@
     }
 
     parse(xml) {
-      var block, k, l, len, len1, len2, m, material, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
+      var block, i, k, l, len, len1, len2, m, material, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
       xml_blocks = $(xml).find('block');
       for (k = 0, len = xml_blocks.length; k < len; k++) {
         xml_block = xml_blocks[k];
@@ -1314,7 +1314,24 @@
         if (block.usetexture.id === 'default') {
           block.usetexture.id = 'dirt';
         }
-        block.texture_name = this.assets.theme.texture_params(block.usetexture.id).file;
+        texture_params = this.assets.theme.texture_params(block.usetexture.id);
+        if (texture_params.frames > 0) {
+          block.animated = true;
+          block.frames_count = texture_params.frames;
+          block.delay = texture_params.delay;
+          block.frame_names = (function() {
+            var l, ref, results;
+            results = [];
+            for (i = l = 0, ref = texture_params.frames - 1; (0 <= ref ? l <= ref : l >= ref); i = 0 <= ref ? ++l : --l) {
+              results.push(this.frame_name(texture_params, i));
+            }
+            return results;
+          }).call(this);
+          block.texture_name = block.frame_names[0];
+        } else {
+          block.animated = false;
+          block.texture_name = texture_params.file;
+        }
         xml_materials = $(xml_block).find('edges material');
         for (l = 0, len1 = xml_materials.length; l < len1; l++) {
           xml_material = xml_materials[l];
@@ -1353,12 +1370,20 @@
     }
 
     load_assets() {
-      var block, k, len, ref, results;
+      var block, frame_name, k, l, len, len1, ref, ref1, results;
       ref = this.list;
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
         block = ref[k];
-        this.assets.textures.push(block.texture_name);
+        if (block.animated) {
+          ref1 = block.frame_names;
+          for (l = 0, len1 = ref1.length; l < len1; l++) {
+            frame_name = ref1[l];
+            this.assets.textures.push(frame_name);
+          }
+        } else {
+          this.assets.textures.push(block.texture_name);
+        }
         results.push(block.edges_list.load_assets());
       }
       return results;
@@ -1395,36 +1420,56 @@
     }
 
     init_sprites() {
-      var block, k, len, matrix, points, ref, results, texture;
+      var block, k, len, name, ref, results;
       ref = this.list;
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
         block = ref[k];
         // Build polygon in world PIXI coordinates (y inverted)
-        points = block.vertices.map(function(v) {
+        block.points = block.vertices.map(function(v) {
           return new PIXI.Point(v.absolute_x, -v.absolute_y);
         });
-        // Load block texture
-        texture = PIXI.Texture.from(this.assets.get_url(block.texture_name));
         // Not translating the matrix ensures texture continuity between blocks
-        matrix = new PIXI.Matrix();
-        matrix.scale(block.usetexture.scale / 60.0, -block.usetexture.scale / 60.0);
-        //matrix.translate(block.aabb.lowerBound.x, -block.aabb.upperBound.y)
-
+        block.matrix = new PIXI.Matrix();
+        block.matrix.scale(block.usetexture.scale / 60.0, -block.usetexture.scale / 60.0);
+        //block.matrix.translate(block.aabb.lowerBound.x, -block.aabb.upperBound.y)
+        if (block.animated) {
+          block.frame_textures = (function() {
+            var l, len1, ref1, results1;
+            ref1 = block.frame_names;
+            results1 = [];
+            for (l = 0, len1 = ref1.length; l < len1; l++) {
+              name = ref1[l];
+              results1.push(PIXI.Texture.from(this.assets.get_url(name)));
+            }
+            return results1;
+          }).call(this);
+          block.current_frame = 0;
+          // Stagger the animation start so neighbouring blocks of the same texture
+          // don't tear: they all share the same wall-clock based frame index.
+          block.animation_start = performance.now();
+        } else {
+          block.texture = PIXI.Texture.from(this.assets.get_url(block.texture_name));
+        }
         // Create graphics with texture and matrix
         block.graphics = new PIXI.Graphics();
         block.graphics.label = block.id;
-        block.graphics.poly(points);
-        block.graphics.fill({
-          texture: texture,
-          matrix: matrix,
-          color: 0xffffff,
-          alpha: 1.0,
-          textureSpace: 'global'
-        });
+        this.draw_block_fill(block, block.animated ? block.frame_textures[0] : block.texture);
         results.push(this.level.layers.layer_for_block(block).addChild(block.graphics));
       }
       return results;
+    }
+
+    draw_block_fill(block, texture) {
+      block.graphics.clear();
+      block.graphics.poly(block.points);
+      return block.graphics.fill({
+        texture: texture,
+        matrix: block.matrix,
+        color: 0xffffff,
+        alpha: 1.0,
+        textureSpace: 'global'
+      });
     }
 
     // One Graphic is created in each block layer (parallax or static)
@@ -1454,17 +1499,31 @@
     }
 
     update() {
-      var block, k, len, ref;
+      var block, k, len, now, ref;
       if (!Constants.debug_physics) {
+        now = performance.now();
         ref = this.list;
         for (k = 0, len = ref.length; k < len; k++) {
           block = ref[k];
           block.graphics.visible = this.visible(block);
           block.edges_list.update();
+          if (block.animated && block.graphics.visible) {
+            this.update_animation(block, now);
+          }
         }
       }
       if (Constants.debug_culling) {
         return this.draw_debug_culling();
+      }
+    }
+
+    update_animation(block, now) {
+      var elapsed, frame;
+      elapsed = (now - block.animation_start) / 1000.0;
+      frame = Math.floor(elapsed / block.delay) % block.frames_count;
+      if (frame !== block.current_frame) {
+        block.current_frame = frame;
+        return this.draw_block_fill(block, block.frame_textures[frame]);
       }
     }
 
@@ -1529,6 +1588,10 @@
       aabb.lowerBound.Set(Math.min.apply(null, x_positions), Math.min.apply(null, y_positions));
       aabb.upperBound.Set(Math.max.apply(null, x_positions), Math.max.apply(null, y_positions));
       return aabb;
+    }
+
+    frame_name(texture_params, frame_number) {
+      return `${texture_params.file_base}${(frame_number / 100.0).toFixed(2).toString().substring(2)}.${texture_params.file_extension}`;
     }
 
     // Blocks drawing is sorted by textures:
@@ -4328,7 +4391,7 @@
     }
 
     load_theme(xml) {
-      var k, len, xml_sprite, xml_sprites;
+      var existing, frames, k, len, name, ref, xml_sprite, xml_sprites;
       xml_sprites = $(xml).find('sprite');
       for (k = 0, len = xml_sprites.length; k < len; k++) {
         xml_sprite = xml_sprites[k];
@@ -4355,13 +4418,18 @@
             depth: parseFloat($(xml_sprite).attr('depth'))
           };
         } else if ($(xml_sprite).attr('type') === 'Texture') {
-          this.textures[$(xml_sprite).attr('name').toLowerCase()] = {
-            file: $(xml_sprite).attr('file') ? $(xml_sprite).attr('file').toLowerCase() : '',
-            file_base: $(xml_sprite).attr('fileBase'),
-            file_extension: $(xml_sprite).attr('fileExtension'),
-            frames: $(xml_sprite).find('frame').length,
-            delay: parseFloat($(xml_sprite).attr('delay'))
-          };
+          name = $(xml_sprite).attr('name').toLowerCase();
+          frames = $(xml_sprite).find('frame').length;
+          existing = this.textures[name];
+          if (!existing || existing.frames === 0) {
+            this.textures[name] = {
+              file: $(xml_sprite).attr('file') ? $(xml_sprite).attr('file').toLowerCase() : '',
+              file_base: $(xml_sprite).attr('fileBase'),
+              file_extension: (ref = $(xml_sprite).attr('fileExtension')) != null ? ref.toLowerCase() : void 0,
+              frames: frames,
+              delay: parseFloat($(xml_sprite).attr('delay'))
+            };
+          }
         }
       }
       return this.callback();

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1274,7 +1274,7 @@
     }
 
     parse(xml) {
-      var block, i, k, l, len, len1, len2, m, material, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
+      var block, k, l, len, len1, len2, m, material, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
       xml_blocks = $(xml).find('block');
       for (k = 0, len = xml_blocks.length; k < len; k++) {
         xml_block = xml_blocks[k];
@@ -1316,20 +1316,10 @@
         }
         texture_params = this.assets.theme.texture_params(block.usetexture.id);
         if (texture_params.frames_count > 0) {
-          block.animated = true;
           block.frames_count = texture_params.frames_count;
           block.delay = texture_params.delay;
-          block.frame_names = (function() {
-            var l, ref, results;
-            results = [];
-            for (i = l = 0, ref = texture_params.frames_count - 1; (0 <= ref ? l <= ref : l >= ref); i = 0 <= ref ? ++l : --l) {
-              results.push(this.frame_name(texture_params, i));
-            }
-            return results;
-          }).call(this);
-          block.texture_name = block.frame_names[0];
+          block.texture_names = this.texture_names(texture_params);
         } else {
-          block.animated = false;
           block.texture_name = texture_params.file;
         }
         xml_materials = $(xml_block).find('edges material');
@@ -1370,16 +1360,16 @@
     }
 
     load_assets() {
-      var block, frame_name, k, l, len, len1, ref, ref1, results;
+      var block, k, l, len, len1, ref, ref1, results, texture_name;
       ref = this.list;
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
         block = ref[k];
-        if (block.animated) {
-          ref1 = block.frame_names;
+        if (block.frames_count > 0) {
+          ref1 = block.texture_names;
           for (l = 0, len1 = ref1.length; l < len1; l++) {
-            frame_name = ref1[l];
-            this.assets.textures.push(frame_name);
+            texture_name = ref1[l];
+            this.assets.textures.push(texture_name);
           }
         } else {
           this.assets.textures.push(block.texture_name);
@@ -1429,10 +1419,10 @@
         block.points = block.vertices.map(function(v) {
           return new PIXI.Point(v.absolute_x, -v.absolute_y);
         });
-        if (block.animated) {
+        if (block.frames_count) {
           block.textures = (function() {
             var l, len1, ref1, results1;
-            ref1 = block.frame_names;
+            ref1 = block.texture_names;
             results1 = [];
             for (l = 0, len1 = ref1.length; l < len1; l++) {
               name = ref1[l];
@@ -1530,7 +1520,7 @@
           block = ref[k];
           block.graphics.visible = this.visible(block);
           block.edges_list.update();
-          if (block.animated && block.graphics.visible) {
+          if (block.frames_count > 0 && block.graphics.visible) {
             this.update_animation(block, now);
           }
         }
@@ -1613,8 +1603,13 @@
       return aabb;
     }
 
-    frame_name(texture_params, frame_number) {
-      return `${texture_params.file_base}${(frame_number / 100.0).toFixed(2).toString().substring(2)}.${texture_params.file_extension}`;
+    texture_names(texture_params) {
+      var frame_i, k, ref, results;
+      results = [];
+      for (frame_i = k = 0, ref = texture_params.frames_count - 1; (0 <= ref ? k <= ref : k >= ref); frame_i = 0 <= ref ? ++k : --k) {
+        results.push(`${texture_params.file_base}${(frame_i / 100.0).toFixed(2).toString().substring(2)}.${texture_params.file_extension}`);
+      }
+      return results;
     }
 
     // Blocks drawing is sorted by textures:

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1274,7 +1274,7 @@
     }
 
     parse(xml) {
-      var block, i, k, l, len, len1, len2, material, o, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
+      var block, i, k, l, len, len1, len2, m, material, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
       xml_blocks = $(xml).find('block');
       for (k = 0, len = xml_blocks.length; k < len; k++) {
         xml_block = xml_blocks[k];
@@ -1348,8 +1348,8 @@
           block.edges.materials.push(material);
         }
         xml_vertices = $(xml_block).find('vertex');
-        for (o = 0, len2 = xml_vertices.length; o < len2; o++) {
-          xml_vertex = xml_vertices[o];
+        for (m = 0, len2 = xml_vertices.length; m < len2; m++) {
+          xml_vertex = xml_vertices[m];
           vertex = {
             x: parseFloat($(xml_vertex).attr('x')),
             y: parseFloat($(xml_vertex).attr('y')),
@@ -1420,7 +1420,7 @@
     }
 
     init_sprites() {
-      var block, k, l, len, len1, m, name, ref, ref1, results, source, texture;
+      var block, k, l, len, len1, name, ref, ref1, results, texture;
       ref = this.list;
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
@@ -1430,7 +1430,7 @@
           return new PIXI.Point(v.absolute_x, -v.absolute_y);
         });
         if (block.animated) {
-          block.frame_textures = (function() {
+          block.textures = (function() {
             var l, len1, ref1, results1;
             ref1 = block.frame_names;
             results1 = [];
@@ -1440,56 +1440,33 @@
             }
             return results1;
           }).call(this);
-          ref1 = block.frame_textures;
-          // Enable repeat wrap so UVs outside 0..1 tile the texture
-          // (mimicking the textureSpace: 'global' behaviour of Graphics fills).
-          for (l = 0, len1 = ref1.length; l < len1; l++) {
-            texture = ref1[l];
-            texture.source.style.addressMode = 'repeat';
-          }
           block.current_frame = 0;
           block.animation_start = performance.now();
-          block.graphics = this.build_animated_mesh(block);
         } else {
-          // Static blocks keep the Graphics + global-space texture matrix path.
-          // Not translating the matrix ensures texture continuity between blocks.
-          // We want UV per world unit = scale * 0.25 (xmoto C++ convention,
-          // see src/xmscene/Block.cpp: texturePos = world * scale * 0.25).
-          // PIXI's textureSpace='global' inverts our matrix then multiplies by
-          // 1/source.size, so we pre-compensate with source.size to cancel that
-          // out and land on the texture-size-independent xmoto factor.
-          block.texture = PIXI.Texture.from(this.assets.get_url(block.texture_name));
-          source = block.texture.source;
-          m = 4.0 / block.usetexture.scale;
-          block.matrix = new PIXI.Matrix();
-          block.matrix.scale(m / source.width, -m / source.height);
-          block.graphics = new PIXI.Graphics();
-          this.draw_static_block_fill(block);
+          block.textures = [PIXI.Texture.from(this.assets.get_url(block.texture_name))];
         }
+        ref1 = block.textures;
+        // 'repeat' wrap lets UVs > 1 tile the texture across the polygon.
+        for (l = 0, len1 = ref1.length; l < len1; l++) {
+          texture = ref1[l];
+          texture.source.style.addressMode = 'repeat';
+        }
+        block.graphics = this.build_mesh(block);
         block.graphics.label = block.id;
         results.push(this.level.layers.layer_for_block(block).addChild(block.graphics));
       }
       return results;
     }
 
-    draw_static_block_fill(block) {
-      block.graphics.clear();
-      block.graphics.poly(block.points);
-      return block.graphics.fill({
-        texture: block.texture,
-        matrix: block.matrix,
-        color: 0xffffff,
-        alpha: 1.0,
-        textureSpace: 'global'
-      });
-    }
+    // Every block (static or animated) is rendered as a Mesh. Animated blocks
+    // later swap mesh.texture between frame textures; static blocks just keep
+    // their single texture.
 
-    // Animated blocks use a Mesh so we can swap textures without rebuilding geometry.
     // UV per world unit = scale * 0.25, matching xmoto C++
     // (src/xmscene/Block.cpp: texturePos = world * scale * 0.25). Combined with
     // the source's 'repeat' wrap, the texture tiles every 4 world units at
     // scale=1, independently of texture pixel size.
-    build_animated_mesh(block) {
+    build_mesh(block) {
       var geometry, i, indices, k, len, point, positions, ref, uv_scale, uvs;
       uv_scale = 0.25 * block.usetexture.scale;
       positions = new Float32Array(block.points.length * 2);
@@ -1510,7 +1487,7 @@
       });
       return new PIXI.Mesh({
         geometry: geometry,
-        texture: block.frame_textures[0]
+        texture: block.textures[0]
       });
     }
 
@@ -1565,12 +1542,12 @@
       frame = Math.floor(elapsed / block.delay) % block.frames_count;
       if (frame !== block.current_frame) {
         block.current_frame = frame;
-        return block.graphics.texture = block.frame_textures[frame];
+        return block.graphics.texture = block.textures[frame];
       }
     }
 
     draw_debug_culling() {
-      var block, calling_debug, culling_debug, culling_debugs, k, l, layer, len, len1, len2, line_width, o, ref, ref1, results;
+      var block, calling_debug, culling_debug, culling_debugs, k, l, layer, len, len1, len2, line_width, m, ref, ref1, results;
       culling_debugs = Object.values(this.culling_debug_graphics);
       for (k = 0, len = culling_debugs.length; k < len; k++) {
         culling_debug = culling_debugs[k];
@@ -1588,8 +1565,8 @@
       ref1 = Object.values(this.culling_debug_graphics);
       // Parallax layers use a fixed 1px stroke (pixelLine) to stay readable
       results = [];
-      for (o = 0, len2 = ref1.length; o < len2; o++) {
-        calling_debug = ref1[o];
+      for (m = 0, len2 = ref1.length; m < len2; m++) {
+        calling_debug = ref1[m];
         if (calling_debug.parallax) {
           results.push(calling_debug.stroke({
             color: 0xC7C778,
@@ -1851,7 +1828,7 @@
     // Collects the surface vertices from run.start through (run.end + 1),
     // then builds a triangle strip projecting downward by theme.depth.
     build_edge_polygon(vertices, run, theme) {
-      var bot_curr, bot_next, closing_idx, depth, dx, dy, i, indices, k, l, lengths, n, o, p, poly_vertices, ref, ref1, ref2, ref3, s, scale, surface, surface_count, uvs, v;
+      var bot_curr, bot_next, closing_idx, depth, dx, dy, i, indices, k, l, lengths, m, n, o, poly_vertices, ref, ref1, ref2, ref3, s, scale, surface, surface_count, uvs, v;
       n = vertices.length;
       depth = theme.depth;
       scale = theme.scale;
@@ -1890,7 +1867,7 @@
         });
         uvs.push(lengths[s] * scale, 0.0);
       }
-      for (s = o = 0, ref2 = surface_count; (0 <= ref2 ? o < ref2 : o > ref2); s = 0 <= ref2 ? ++o : --o) {
+      for (s = m = 0, ref2 = surface_count; (0 <= ref2 ? m < ref2 : m > ref2); s = 0 <= ref2 ? ++m : --m) {
         v = surface[surface_count - 1 - s];
         poly_vertices.push({
           x: v.x,
@@ -1900,7 +1877,7 @@
       }
       // Triangle strip indices (2 triangles per segment)
       indices = [];
-      for (s = p = 0, ref3 = surface_count - 1; (0 <= ref3 ? p < ref3 : p > ref3); s = 0 <= ref3 ? ++p : --p) {
+      for (s = o = 0, ref3 = surface_count - 1; (0 <= ref3 ? o < ref3 : o > ref3); s = 0 <= ref3 ? ++o : --o) {
         bot_curr = 2 * surface_count - 1 - s;
         bot_next = 2 * surface_count - 2 - s;
         indices.push(s, s + 1, bot_curr);
@@ -3105,7 +3082,7 @@
     }
 
     init_sprites() {
-      var asset_name, axle_name, k, l, len, len1, len2, o, part, ref, ref1, ref2, wheel_name;
+      var asset_name, axle_name, k, l, len, len1, len2, m, part, ref, ref1, ref2, wheel_name;
       ref = ['body', 'left_wheel', 'right_wheel', 'left_axle', 'right_axle'];
       // Create and add sprites to the scene
       for (k = 0, len = ref.length; k < len; k++) {
@@ -3135,8 +3112,8 @@
       }
       ref2 = ['left_axle', 'right_axle'];
       // Define axles values
-      for (o = 0, len2 = ref2.length; o < len2; o++) {
-        axle_name = ref2[o];
+      for (m = 0, len2 = ref2.length; m < len2; m++) {
+        axle_name = ref2[m];
         this[`${axle_name}_sprite`].anchor.x = 0.0;
         this[`${axle_name}_sprite`].anchor.y = 0.5;
       }
@@ -4200,7 +4177,7 @@
     }
 
     load(callback) {
-      var item, items, k, l, len, len1, len2, len3, o, p, ref, ref1, ref2, ref3, urls;
+      var item, items, k, l, len, len1, len2, len3, m, o, ref, ref1, ref2, ref3, urls;
       items = [];
       ref = this.textures;
       for (k = 0, len = ref.length; k < len; k++) {
@@ -4219,16 +4196,16 @@
         });
       }
       ref2 = this.effects;
-      for (o = 0, len2 = ref2.length; o < len2; o++) {
-        item = ref2[o];
+      for (m = 0, len2 = ref2.length; m < len2; m++) {
+        item = ref2[m];
         items.push({
           id: item,
           src: `/data/Textures/Effects/${item.toLowerCase()}`
         });
       }
       ref3 = this.moto;
-      for (p = 0, len3 = ref3.length; p < len3; p++) {
-        item = ref3[p];
+      for (o = 0, len3 = ref3.length; o < len3; o++) {
+        item = ref3[o];
         items.push({
           id: item,
           src: `/data/Textures/Riders/${item.toLowerCase()}`
@@ -4239,9 +4216,9 @@
         return item.src;
       });
       return PIXI.Assets.load(urls).then(() => {
-        var len4, q;
-        for (q = 0, len4 = items.length; q < len4; q++) {
-          item = items[q];
+        var len4, p;
+        for (p = 0, len4 = items.length; p < len4; p++) {
+          item = items[p];
           this.resources[item.id] = {
             url: item.src
           };

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1297,7 +1297,7 @@
             })()
           },
           usetexture: {
-            id: $(xml_block).find('usetexture').attr('id').toLowerCase(),
+            id: $(xml_block).find('usetexture').attr('id'),
             scale: parseFloat($(xml_block).find('usetexture').attr('scale')) || 1.0
           },
           physics: {
@@ -1355,7 +1355,7 @@
             y: parseFloat($(xml_vertex).attr('y')),
             absolute_x: parseFloat($(xml_vertex).attr('x')) + block.position.x, // absolutes positions are practical
             absolute_y: parseFloat($(xml_vertex).attr('y')) + block.position.y, // for edges creation
-            edge: $(xml_vertex).attr('edge') ? $(xml_vertex).attr('edge').toLowerCase() : void 0
+            edge: $(xml_vertex).attr('edge')
           };
           block.vertices.push(vertex);
         }
@@ -2756,7 +2756,7 @@
     parse(xml) {
       var xml_sky;
       xml_sky = $(xml).find('level info sky');
-      this.name = xml_sky.text().toLowerCase();
+      this.name = xml_sky.text();
       this.color_r = parseInt(xml_sky.attr('color_r'));
       this.color_g = parseInt(xml_sky.attr('color_g'));
       this.color_b = parseInt(xml_sky.attr('color_b'));
@@ -4414,12 +4414,13 @@
     }
 
     load_theme(xml) {
-      var existing, frames, k, len, name, ref, xml_sprite, xml_sprites;
+      var existing, frames, k, len, name, xml_sprite, xml_sprites;
       xml_sprites = $(xml).find('sprite');
       for (k = 0, len = xml_sprites.length; k < len; k++) {
         xml_sprite = xml_sprites[k];
+        name = $(xml_sprite).attr('name').toLowerCase();
         if ($(xml_sprite).attr('type') === 'Entity') {
-          this.sprites[$(xml_sprite).attr('name')] = {
+          this.sprites[name] = {
             file: $(xml_sprite).attr('file'),
             file_base: $(xml_sprite).attr('fileBase'),
             file_extension: $(xml_sprite).attr('fileExtension'),
@@ -4435,20 +4436,19 @@
             delay: parseFloat($(xml_sprite).attr('delay'))
           };
         } else if ($(xml_sprite).attr('type') === 'EdgeEffect') {
-          this.edges[$(xml_sprite).attr('name').toLowerCase()] = {
-            file: $(xml_sprite).attr('file').toLowerCase(),
+          this.edges[name] = {
+            file: $(xml_sprite).attr('file'),
             scale: parseFloat($(xml_sprite).attr('scale')),
             depth: parseFloat($(xml_sprite).attr('depth'))
           };
         } else if ($(xml_sprite).attr('type') === 'Texture') {
-          name = $(xml_sprite).attr('name').toLowerCase();
           frames = $(xml_sprite).find('frame').length;
           existing = this.textures[name];
           if (!existing || existing.frames === 0) {
             this.textures[name] = {
-              file: $(xml_sprite).attr('file') ? $(xml_sprite).attr('file').toLowerCase() : '',
+              file: $(xml_sprite).attr('file'),
               file_base: $(xml_sprite).attr('fileBase'),
-              file_extension: (ref = $(xml_sprite).attr('fileExtension')) != null ? ref.toLowerCase() : void 0,
+              file_extension: $(xml_sprite).attr('fileExtension'),
               frames: frames,
               delay: parseFloat($(xml_sprite).attr('delay'))
             };
@@ -4459,15 +4459,15 @@
     }
 
     sprite_params(name) {
-      return this.sprites[name];
+      return this.sprites[name.toLowerCase()];
     }
 
     edge_params(name) {
-      return this.edges[name];
+      return this.edges[name.toLowerCase()];
     }
 
     texture_params(name) {
-      return this.textures[name];
+      return this.textures[name.toLowerCase()];
     }
 
   };

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1274,7 +1274,7 @@
     }
 
     parse(xml) {
-      var block, i, k, l, len, len1, len2, m, material, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
+      var block, i, k, l, len, len1, len2, material, o, texture_params, vertex, xml_block, xml_blocks, xml_material, xml_materials, xml_vertex, xml_vertices;
       xml_blocks = $(xml).find('block');
       for (k = 0, len = xml_blocks.length; k < len; k++) {
         xml_block = xml_blocks[k];
@@ -1348,8 +1348,8 @@
           block.edges.materials.push(material);
         }
         xml_vertices = $(xml_block).find('vertex');
-        for (m = 0, len2 = xml_vertices.length; m < len2; m++) {
-          xml_vertex = xml_vertices[m];
+        for (o = 0, len2 = xml_vertices.length; o < len2; o++) {
+          xml_vertex = xml_vertices[o];
           vertex = {
             x: parseFloat($(xml_vertex).attr('x')),
             y: parseFloat($(xml_vertex).attr('y')),
@@ -1420,7 +1420,7 @@
     }
 
     init_sprites() {
-      var block, k, len, name, ref, results;
+      var block, k, l, len, len1, m, name, ref, ref1, results, source, texture;
       ref = this.list;
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
@@ -1429,10 +1429,6 @@
         block.points = block.vertices.map(function(v) {
           return new PIXI.Point(v.absolute_x, -v.absolute_y);
         });
-        // Not translating the matrix ensures texture continuity between blocks
-        block.matrix = new PIXI.Matrix();
-        block.matrix.scale(block.usetexture.scale / 60.0, -block.usetexture.scale / 60.0);
-        //block.matrix.translate(block.aabb.lowerBound.x, -block.aabb.upperBound.y)
         if (block.animated) {
           block.frame_textures = (function() {
             var l, len1, ref1, results1;
@@ -1444,31 +1440,77 @@
             }
             return results1;
           }).call(this);
+          ref1 = block.frame_textures;
+          // Enable repeat wrap so UVs outside 0..1 tile the texture
+          // (mimicking the textureSpace: 'global' behaviour of Graphics fills).
+          for (l = 0, len1 = ref1.length; l < len1; l++) {
+            texture = ref1[l];
+            texture.source.style.addressMode = 'repeat';
+          }
           block.current_frame = 0;
-          // Stagger the animation start so neighbouring blocks of the same texture
-          // don't tear: they all share the same wall-clock based frame index.
           block.animation_start = performance.now();
+          block.graphics = this.build_animated_mesh(block);
         } else {
+          // Static blocks keep the Graphics + global-space texture matrix path.
+          // Not translating the matrix ensures texture continuity between blocks.
+          // We want UV per world unit = scale * 0.25 (xmoto C++ convention,
+          // see src/xmscene/Block.cpp: texturePos = world * scale * 0.25).
+          // PIXI's textureSpace='global' inverts our matrix then multiplies by
+          // 1/source.size, so we pre-compensate with source.size to cancel that
+          // out and land on the texture-size-independent xmoto factor.
           block.texture = PIXI.Texture.from(this.assets.get_url(block.texture_name));
+          source = block.texture.source;
+          m = 4.0 / block.usetexture.scale;
+          block.matrix = new PIXI.Matrix();
+          block.matrix.scale(m / source.width, -m / source.height);
+          block.graphics = new PIXI.Graphics();
+          this.draw_static_block_fill(block);
         }
-        // Create graphics with texture and matrix
-        block.graphics = new PIXI.Graphics();
         block.graphics.label = block.id;
-        this.draw_block_fill(block, block.animated ? block.frame_textures[0] : block.texture);
         results.push(this.level.layers.layer_for_block(block).addChild(block.graphics));
       }
       return results;
     }
 
-    draw_block_fill(block, texture) {
+    draw_static_block_fill(block) {
       block.graphics.clear();
       block.graphics.poly(block.points);
       return block.graphics.fill({
-        texture: texture,
+        texture: block.texture,
         matrix: block.matrix,
         color: 0xffffff,
         alpha: 1.0,
         textureSpace: 'global'
+      });
+    }
+
+    // Animated blocks use a Mesh so we can swap textures without rebuilding geometry.
+    // UV per world unit = scale * 0.25, matching xmoto C++
+    // (src/xmscene/Block.cpp: texturePos = world * scale * 0.25). Combined with
+    // the source's 'repeat' wrap, the texture tiles every 4 world units at
+    // scale=1, independently of texture pixel size.
+    build_animated_mesh(block) {
+      var geometry, i, indices, k, len, point, positions, ref, uv_scale, uvs;
+      uv_scale = 0.25 * block.usetexture.scale;
+      positions = new Float32Array(block.points.length * 2);
+      uvs = new Float32Array(block.points.length * 2);
+      ref = block.points;
+      for (i = k = 0, len = ref.length; k < len; i = ++k) {
+        point = ref[i];
+        positions[i * 2] = point.x;
+        positions[i * 2 + 1] = point.y;
+        uvs[i * 2] = uv_scale * point.x;
+        uvs[i * 2 + 1] = -uv_scale * point.y;
+      }
+      indices = new Uint16Array(PIXI.earcut(positions));
+      geometry = new PIXI.MeshGeometry({
+        positions: positions,
+        uvs: uvs,
+        indices: indices
+      });
+      return new PIXI.Mesh({
+        geometry: geometry,
+        texture: block.frame_textures[0]
       });
     }
 
@@ -1523,12 +1565,12 @@
       frame = Math.floor(elapsed / block.delay) % block.frames_count;
       if (frame !== block.current_frame) {
         block.current_frame = frame;
-        return this.draw_block_fill(block, block.frame_textures[frame]);
+        return block.graphics.texture = block.frame_textures[frame];
       }
     }
 
     draw_debug_culling() {
-      var block, calling_debug, culling_debug, culling_debugs, k, l, layer, len, len1, len2, line_width, m, ref, ref1, results;
+      var block, calling_debug, culling_debug, culling_debugs, k, l, layer, len, len1, len2, line_width, o, ref, ref1, results;
       culling_debugs = Object.values(this.culling_debug_graphics);
       for (k = 0, len = culling_debugs.length; k < len; k++) {
         culling_debug = culling_debugs[k];
@@ -1546,8 +1588,8 @@
       ref1 = Object.values(this.culling_debug_graphics);
       // Parallax layers use a fixed 1px stroke (pixelLine) to stay readable
       results = [];
-      for (m = 0, len2 = ref1.length; m < len2; m++) {
-        calling_debug = ref1[m];
+      for (o = 0, len2 = ref1.length; o < len2; o++) {
+        calling_debug = ref1[o];
         if (calling_debug.parallax) {
           results.push(calling_debug.stroke({
             color: 0xC7C778,
@@ -1809,7 +1851,7 @@
     // Collects the surface vertices from run.start through (run.end + 1),
     // then builds a triangle strip projecting downward by theme.depth.
     build_edge_polygon(vertices, run, theme) {
-      var bot_curr, bot_next, closing_idx, depth, dx, dy, i, indices, k, l, lengths, m, n, o, poly_vertices, ref, ref1, ref2, ref3, s, scale, surface, surface_count, uvs, v;
+      var bot_curr, bot_next, closing_idx, depth, dx, dy, i, indices, k, l, lengths, n, o, p, poly_vertices, ref, ref1, ref2, ref3, s, scale, surface, surface_count, uvs, v;
       n = vertices.length;
       depth = theme.depth;
       scale = theme.scale;
@@ -1848,7 +1890,7 @@
         });
         uvs.push(lengths[s] * scale, 0.0);
       }
-      for (s = m = 0, ref2 = surface_count; (0 <= ref2 ? m < ref2 : m > ref2); s = 0 <= ref2 ? ++m : --m) {
+      for (s = o = 0, ref2 = surface_count; (0 <= ref2 ? o < ref2 : o > ref2); s = 0 <= ref2 ? ++o : --o) {
         v = surface[surface_count - 1 - s];
         poly_vertices.push({
           x: v.x,
@@ -1858,7 +1900,7 @@
       }
       // Triangle strip indices (2 triangles per segment)
       indices = [];
-      for (s = o = 0, ref3 = surface_count - 1; (0 <= ref3 ? o < ref3 : o > ref3); s = 0 <= ref3 ? ++o : --o) {
+      for (s = p = 0, ref3 = surface_count - 1; (0 <= ref3 ? p < ref3 : p > ref3); s = 0 <= ref3 ? ++p : --p) {
         bot_curr = 2 * surface_count - 1 - s;
         bot_next = 2 * surface_count - 2 - s;
         indices.push(s, s + 1, bot_curr);
@@ -3063,7 +3105,7 @@
     }
 
     init_sprites() {
-      var asset_name, axle_name, k, l, len, len1, len2, m, part, ref, ref1, ref2, wheel_name;
+      var asset_name, axle_name, k, l, len, len1, len2, o, part, ref, ref1, ref2, wheel_name;
       ref = ['body', 'left_wheel', 'right_wheel', 'left_axle', 'right_axle'];
       // Create and add sprites to the scene
       for (k = 0, len = ref.length; k < len; k++) {
@@ -3093,8 +3135,8 @@
       }
       ref2 = ['left_axle', 'right_axle'];
       // Define axles values
-      for (m = 0, len2 = ref2.length; m < len2; m++) {
-        axle_name = ref2[m];
+      for (o = 0, len2 = ref2.length; o < len2; o++) {
+        axle_name = ref2[o];
         this[`${axle_name}_sprite`].anchor.x = 0.0;
         this[`${axle_name}_sprite`].anchor.y = 0.5;
       }
@@ -4158,7 +4200,7 @@
     }
 
     load(callback) {
-      var item, items, k, l, len, len1, len2, len3, m, o, ref, ref1, ref2, ref3, urls;
+      var item, items, k, l, len, len1, len2, len3, o, p, ref, ref1, ref2, ref3, urls;
       items = [];
       ref = this.textures;
       for (k = 0, len = ref.length; k < len; k++) {
@@ -4177,16 +4219,16 @@
         });
       }
       ref2 = this.effects;
-      for (m = 0, len2 = ref2.length; m < len2; m++) {
-        item = ref2[m];
+      for (o = 0, len2 = ref2.length; o < len2; o++) {
+        item = ref2[o];
         items.push({
           id: item,
           src: `/data/Textures/Effects/${item.toLowerCase()}`
         });
       }
       ref3 = this.moto;
-      for (o = 0, len3 = ref3.length; o < len3; o++) {
-        item = ref3[o];
+      for (p = 0, len3 = ref3.length; p < len3; p++) {
+        item = ref3[p];
         items.push({
           id: item,
           src: `/data/Textures/Riders/${item.toLowerCase()}`
@@ -4197,9 +4239,9 @@
         return item.src;
       });
       return PIXI.Assets.load(urls).then(() => {
-        var len4, p;
-        for (p = 0, len4 = items.length; p < len4; p++) {
-          item = items[p];
+        var len4, q;
+        for (q = 0, len4 = items.length; q < len4; q++) {
+          item = items[q];
           this.resources[item.id] = {
             url: item.src
           };

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1449,7 +1449,7 @@
         // 'repeat' wrap lets UVs > 1 tile the texture across the polygon.
         for (l = 0, len1 = ref1.length; l < len1; l++) {
           texture = ref1[l];
-          texture.source.style.addressMode = 'repeat';
+          texture.source.addressMode = 'repeat';
         }
         block.graphics = this.build_mesh(block);
         block.graphics.label = block.id;
@@ -1479,7 +1479,7 @@
         uvs[i * 2] = uv_scale * point.x;
         uvs[i * 2 + 1] = -uv_scale * point.y;
       }
-      indices = new Uint16Array(PIXI.earcut(positions));
+      indices = new Uint32Array(PIXI.earcut(positions));
       geometry = new PIXI.MeshGeometry({
         positions: positions,
         uvs: uvs,

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1315,14 +1315,14 @@
           block.usetexture.id = 'dirt';
         }
         texture_params = this.assets.theme.texture_params(block.usetexture.id);
-        if (texture_params.frames > 0) {
+        if (texture_params.frames_count > 0) {
           block.animated = true;
-          block.frames_count = texture_params.frames;
+          block.frames_count = texture_params.frames_count;
           block.delay = texture_params.delay;
           block.frame_names = (function() {
             var l, ref, results;
             results = [];
-            for (i = l = 0, ref = texture_params.frames - 1; (0 <= ref ? l <= ref : l >= ref); i = 0 <= ref ? ++l : --l) {
+            for (i = l = 0, ref = texture_params.frames_count - 1; (0 <= ref ? l <= ref : l >= ref); i = 0 <= ref ? ++l : --l) {
               results.push(this.frame_name(texture_params, i));
             }
             return results;
@@ -2059,7 +2059,7 @@
             entity.file_base = theme_sprite.file_base;
             entity.file_extension = theme_sprite.file_extension;
             entity.delay = theme_sprite.delay;
-            entity.frames = theme_sprite.frames;
+            entity.frames_count = theme_sprite.frames_count;
             entity.display = true; // if an entity has a texture, it needs to be displayed
             
             // Default theme values if not defined in XML
@@ -2109,13 +2109,13 @@
       for (k = 0, len = ref.length; k < len; k++) {
         entity = ref[k];
         if (entity.display) {
-          if (entity.frames === 0) {
+          if (entity.frames_count === 0) {
             results.push(this.assets.anims.push(entity.file));
           } else {
             results.push((function() {
               var l, ref1, results1;
               results1 = [];
-              for (i = l = 0, ref1 = entity.frames - 1; (0 <= ref1 ? l <= ref1 : l >= ref1); i = 0 <= ref1 ? ++l : --l) {
+              for (i = l = 0, ref1 = entity.frames_count - 1; (0 <= ref1 ? l <= ref1 : l >= ref1); i = 0 <= ref1 ? ++l : --l) {
                 results1.push(this.assets.anims.push(this.frame_name(entity, i)));
               }
               return results1;
@@ -2208,9 +2208,9 @@
 
     init_sprite(entity, container) {
       var i, k, ref, sprite, textures;
-      if (entity.frames > 0) {
+      if (entity.frames_count > 0) {
         textures = [];
-        for (i = k = 0, ref = entity.frames - 1; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
+        for (i = k = 0, ref = entity.frames_count - 1; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
           textures.push(PIXI.Texture.from(this.assets.get_url(this.frame_name(entity, i))));
         }
         sprite = new PIXI.AnimatedSprite(textures);
@@ -4414,7 +4414,7 @@
     }
 
     load_theme(xml) {
-      var existing, frames, k, len, name, xml_sprite, xml_sprites;
+      var k, len, name, xml_sprite, xml_sprites;
       xml_sprites = $(xml).find('sprite');
       for (k = 0, len = xml_sprites.length; k < len; k++) {
         xml_sprite = xml_sprites[k];
@@ -4432,7 +4432,7 @@
               x: parseFloat($(xml_sprite).attr('centerX')),
               y: parseFloat($(xml_sprite).attr('centerY'))
             },
-            frames: $(xml_sprite).find('frame').length,
+            frames_count: $(xml_sprite).find('frame').length,
             delay: parseFloat($(xml_sprite).attr('delay'))
           };
         } else if ($(xml_sprite).attr('type') === 'EdgeEffect') {
@@ -4442,14 +4442,12 @@
             depth: parseFloat($(xml_sprite).attr('depth'))
           };
         } else if ($(xml_sprite).attr('type') === 'Texture') {
-          frames = $(xml_sprite).find('frame').length;
-          existing = this.textures[name];
-          if (!existing || existing.frames === 0) {
+          if (!this.textures[name] || this.textures[name].frames_count === 0) {
             this.textures[name] = {
               file: $(xml_sprite).attr('file'),
               file_base: $(xml_sprite).attr('fileBase'),
               file_extension: $(xml_sprite).attr('fileExtension'),
-              frames: frames,
+              frames_count: $(xml_sprite).find('frame').length,
               delay: parseFloat($(xml_sprite).attr('delay'))
             };
           }

--- a/bin/xmoto.js
+++ b/bin/xmoto.js
@@ -1315,7 +1315,7 @@
           block.usetexture.id = 'dirt';
         }
         texture_params = this.assets.theme.texture_params(block.usetexture.id);
-        if (texture_params.frames_count > 0) {
+        if (texture_params.frames_count) {
           block.frames_count = texture_params.frames_count;
           block.delay = texture_params.delay;
           block.texture_names = this.texture_names(texture_params);
@@ -1365,7 +1365,7 @@
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
         block = ref[k];
-        if (block.frames_count > 0) {
+        if (block.frames_count) {
           ref1 = block.texture_names;
           for (l = 0, len1 = ref1.length; l < len1; l++) {
             texture_name = ref1[l];
@@ -1410,7 +1410,8 @@
     }
 
     init_sprites() {
-      var block, k, l, len, len1, name, ref, ref1, results, texture;
+      var block, k, l, len, len1, name, now, ref, ref1, results, texture;
+      now = performance.now();
       ref = this.list;
       results = [];
       for (k = 0, len = ref.length; k < len; k++) {
@@ -1419,6 +1420,7 @@
         block.points = block.vertices.map(function(v) {
           return new PIXI.Point(v.absolute_x, -v.absolute_y);
         });
+        // Load block texture(s)
         if (block.frames_count) {
           block.textures = (function() {
             var l, len1, ref1, results1;
@@ -1431,15 +1433,15 @@
             return results1;
           }).call(this);
           block.current_frame = 0;
-          block.animation_start = performance.now();
+          block.animation_start = now;
+          ref1 = block.textures;
+          for (l = 0, len1 = ref1.length; l < len1; l++) {
+            texture = ref1[l];
+            texture.source.addressMode = 'repeat';
+          }
         } else {
-          block.textures = [PIXI.Texture.from(this.assets.get_url(block.texture_name))];
-        }
-        ref1 = block.textures;
-        // 'repeat' wrap lets UVs > 1 tile the texture across the polygon.
-        for (l = 0, len1 = ref1.length; l < len1; l++) {
-          texture = ref1[l];
-          texture.source.addressMode = 'repeat';
+          block.texture = PIXI.Texture.from(this.assets.get_url(block.texture_name));
+          block.texture.source.addressMode = 'repeat';
         }
         block.graphics = this.build_mesh(block);
         block.graphics.label = block.id;
@@ -1448,20 +1450,12 @@
       return results;
     }
 
-    // Every block (static or animated) is rendered as a Mesh. Animated blocks
-    // later swap mesh.texture between frame textures; static blocks just keep
-    // their single texture.
-
-    // UV per world unit = scale * 0.25 * (256 / source.width).
-    // xmoto C++ uses scale * 0.25 directly (src/xmscene/Block.cpp:
-    // texturePos = world * scale * 0.25), which assumes 256-pixel textures and
-    // stretches lower-resolution textures (e.g. 128px clouds/water). Anchoring
-    // on 256 keeps standard-size textures identical to xmoto while tiling
-    // smaller textures proportionally denser for consistent on-screen pixel
-    // density.
+    // Every block (static or animated) is rendered as a Mesh (faster!).
+    // Animated blocks swap mesh.texture between frame textures
     build_mesh(block) {
-      var geometry, i, indices, k, len, point, positions, ref, source, uv_scale, uvs;
-      source = block.textures[0].source;
+      var geometry, i, indices, k, len, point, positions, ref, source, texture, uv_scale, uvs;
+      texture = block.frames_count ? block.textures[0] : block.texture;
+      source = texture.source;
       uv_scale = block.usetexture.scale * 64.0 / source.width;
       positions = new Float32Array(block.points.length * 2);
       uvs = new Float32Array(block.points.length * 2);
@@ -1473,7 +1467,7 @@
         uvs[i * 2] = uv_scale * point.x;
         uvs[i * 2 + 1] = -uv_scale * point.y;
       }
-      indices = new Uint32Array(PIXI.earcut(positions));
+      indices = new Uint32Array(PIXI.earcut(positions)); // Polygon Triangulation
       geometry = new PIXI.MeshGeometry({
         positions: positions,
         uvs: uvs,
@@ -1481,7 +1475,7 @@
       });
       return new PIXI.Mesh({
         geometry: geometry,
-        texture: block.textures[0]
+        texture: texture
       });
     }
 
@@ -1520,7 +1514,7 @@
           block = ref[k];
           block.graphics.visible = this.visible(block);
           block.edges_list.update();
-          if (block.frames_count > 0 && block.graphics.visible) {
+          if (block.frames_count && block.graphics.visible) {
             this.update_animation(block, now);
           }
         }
@@ -2203,7 +2197,7 @@
 
     init_sprite(entity, container) {
       var i, k, ref, sprite, textures;
-      if (entity.frames_count > 0) {
+      if (entity.frames_count) {
         textures = [];
         for (i = k = 0, ref = entity.frames_count - 1; (0 <= ref ? k <= ref : k >= ref); i = 0 <= ref ? ++k : --k) {
           textures.push(PIXI.Texture.from(this.assets.get_url(this.frame_name(entity, i))));

--- a/index.html
+++ b/index.html
@@ -87,7 +87,9 @@
           <option value="l7388.lvl">7388</option>
           <option value="l8682.lvl">8682</option>
 
-<!--           <option value="l1.lvl">1</option>
+          <option value="---">----</option>
+
+          <option value="l1.lvl">1</option>
           <option value="l2.lvl">2</option>
           <option value="l3.lvl">3</option>
           <option value="l4.lvl">4</option>
@@ -3238,7 +3240,7 @@
           <option value="l13238.lvl">13238</option>
           <option value="l13239.lvl">13239</option>
           <option value="l13242.lvl">13242</option>
-          <option value="l13251.lvl">13251</option> -->
+          <option value="l13251.lvl">13251</option>
         </select>
       </div>
 

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -125,7 +125,7 @@ class Blocks
 
       # 'repeat' wrap lets UVs > 1 tile the texture across the polygon.
       for texture in block.textures
-        texture.source.style.addressMode = 'repeat'
+        texture.source.addressMode = 'repeat'
 
       block.graphics       = @build_mesh(block)
       block.graphics.label = block.id
@@ -152,7 +152,7 @@ class Blocks
       uvs[i * 2]           =  uv_scale * point.x
       uvs[i * 2 + 1]       = -uv_scale * point.y
 
-    indices = new Uint16Array(PIXI.earcut(positions))
+    indices = new Uint32Array(PIXI.earcut(positions))
 
     geometry = new PIXI.MeshGeometry({
       positions: positions

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -136,12 +136,16 @@ class Blocks
   # later swap mesh.texture between frame textures; static blocks just keep
   # their single texture.
   #
-  # UV per world unit = scale * 0.25, matching xmoto C++
-  # (src/xmscene/Block.cpp: texturePos = world * scale * 0.25). Combined with
-  # the source's 'repeat' wrap, the texture tiles every 4 world units at
-  # scale=1, independently of texture pixel size.
+  # UV per world unit = scale * 0.25 * (256 / source.width).
+  # xmoto C++ uses scale * 0.25 directly (src/xmscene/Block.cpp:
+  # texturePos = world * scale * 0.25), which assumes 256-pixel textures and
+  # stretches lower-resolution textures (e.g. 128px clouds/water). Anchoring
+  # on 256 keeps standard-size textures identical to xmoto while tiling
+  # smaller textures proportionally denser for consistent on-screen pixel
+  # density.
   build_mesh: (block) ->
-    uv_scale = 0.25 * block.usetexture.scale
+    source   = block.textures[0].source
+    uv_scale = block.usetexture.scale * 64.0 / source.width
 
     positions = new Float32Array(block.points.length * 2)
     uvs       = new Float32Array(block.points.length * 2)

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -116,37 +116,77 @@ class Blocks
         new PIXI.Point(v.absolute_x, -v.absolute_y)
       )
 
-      # Not translating the matrix ensures texture continuity between blocks
-      block.matrix = new PIXI.Matrix()
-      block.matrix.scale(block.usetexture.scale / 60.0, -block.usetexture.scale / 60.0)
-      #block.matrix.translate(block.aabb.lowerBound.x, -block.aabb.upperBound.y)
-
       if block.animated
         block.frame_textures = (PIXI.Texture.from(@assets.get_url(name)) for name in block.frame_names)
-        block.current_frame  = 0
-        # Stagger the animation start so neighbouring blocks of the same texture
-        # don't tear: they all share the same wall-clock based frame index.
+
+        # Enable repeat wrap so UVs outside 0..1 tile the texture
+        # (mimicking the textureSpace: 'global' behaviour of Graphics fills).
+        for texture in block.frame_textures
+          texture.source.style.addressMode = 'repeat'
+
+        block.current_frame   = 0
         block.animation_start = performance.now()
+        block.graphics        = @build_animated_mesh(block)
       else
+        # Static blocks keep the Graphics + global-space texture matrix path.
+        # Not translating the matrix ensures texture continuity between blocks.
+        # We want UV per world unit = scale * 0.25 (xmoto C++ convention,
+        # see src/xmscene/Block.cpp: texturePos = world * scale * 0.25).
+        # PIXI's textureSpace='global' inverts our matrix then multiplies by
+        # 1/source.size, so we pre-compensate with source.size to cancel that
+        # out and land on the texture-size-independent xmoto factor.
         block.texture = PIXI.Texture.from(@assets.get_url(block.texture_name))
+        source        = block.texture.source
+        m             = 4.0 / block.usetexture.scale
 
-      # Create graphics with texture and matrix
-      block.graphics = new PIXI.Graphics()
+        block.matrix = new PIXI.Matrix()
+        block.matrix.scale(m / source.width, -m / source.height)
+
+        block.graphics = new PIXI.Graphics()
+        @draw_static_block_fill(block)
+
       block.graphics.label = block.id
-
-      @draw_block_fill(block, if block.animated then block.frame_textures[0] else block.texture)
-
       @level.layers.layer_for_block(block).addChild(block.graphics)
 
-  draw_block_fill: (block, texture) ->
+  draw_static_block_fill: (block) ->
     block.graphics.clear()
     block.graphics.poly(block.points)
     block.graphics.fill({
-      texture:      texture,
+      texture:      block.texture,
       matrix:       block.matrix,
       color:        0xffffff,
       alpha:        1.0,
       textureSpace: 'global'
+    })
+
+  # Animated blocks use a Mesh so we can swap textures without rebuilding geometry.
+  # UV per world unit = scale * 0.25, matching xmoto C++
+  # (src/xmscene/Block.cpp: texturePos = world * scale * 0.25). Combined with
+  # the source's 'repeat' wrap, the texture tiles every 4 world units at
+  # scale=1, independently of texture pixel size.
+  build_animated_mesh: (block) ->
+    uv_scale =  0.25 * block.usetexture.scale
+
+    positions = new Float32Array(block.points.length * 2)
+    uvs       = new Float32Array(block.points.length * 2)
+
+    for point, i in block.points
+      positions[i * 2]     = point.x
+      positions[i * 2 + 1] = point.y
+      uvs[i * 2]           =  uv_scale * point.x
+      uvs[i * 2 + 1]       = -uv_scale * point.y
+
+    indices = new Uint16Array(PIXI.earcut(positions))
+
+    geometry = new PIXI.MeshGeometry({
+      positions: positions
+      uvs:       uvs
+      indices:   indices
+    })
+
+    new PIXI.Mesh({
+      geometry: geometry
+      texture:  block.frame_textures[0]
     })
 
   # One Graphic is created in each block layer (parallax or static)
@@ -187,7 +227,7 @@ class Blocks
 
     if frame != block.current_frame
       block.current_frame = frame
-      @draw_block_fill(block, block.frame_textures[frame])
+      block.graphics.texture = block.frame_textures[frame]
 
   draw_debug_culling: ->
     culling_debugs = Object.values(@culling_debug_graphics)

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -117,55 +117,31 @@ class Blocks
       )
 
       if block.animated
-        block.frame_textures = (PIXI.Texture.from(@assets.get_url(name)) for name in block.frame_names)
-
-        # Enable repeat wrap so UVs outside 0..1 tile the texture
-        # (mimicking the textureSpace: 'global' behaviour of Graphics fills).
-        for texture in block.frame_textures
-          texture.source.style.addressMode = 'repeat'
-
+        block.textures        = (PIXI.Texture.from(@assets.get_url(name)) for name in block.frame_names)
         block.current_frame   = 0
         block.animation_start = performance.now()
-        block.graphics        = @build_animated_mesh(block)
       else
-        # Static blocks keep the Graphics + global-space texture matrix path.
-        # Not translating the matrix ensures texture continuity between blocks.
-        # We want UV per world unit = scale * 0.25 (xmoto C++ convention,
-        # see src/xmscene/Block.cpp: texturePos = world * scale * 0.25).
-        # PIXI's textureSpace='global' inverts our matrix then multiplies by
-        # 1/source.size, so we pre-compensate with source.size to cancel that
-        # out and land on the texture-size-independent xmoto factor.
-        block.texture = PIXI.Texture.from(@assets.get_url(block.texture_name))
-        source        = block.texture.source
-        m             = 4.0 / block.usetexture.scale
+        block.textures = [PIXI.Texture.from(@assets.get_url(block.texture_name))]
 
-        block.matrix = new PIXI.Matrix()
-        block.matrix.scale(m / source.width, -m / source.height)
+      # 'repeat' wrap lets UVs > 1 tile the texture across the polygon.
+      for texture in block.textures
+        texture.source.style.addressMode = 'repeat'
 
-        block.graphics = new PIXI.Graphics()
-        @draw_static_block_fill(block)
-
+      block.graphics       = @build_mesh(block)
       block.graphics.label = block.id
+
       @level.layers.layer_for_block(block).addChild(block.graphics)
 
-  draw_static_block_fill: (block) ->
-    block.graphics.clear()
-    block.graphics.poly(block.points)
-    block.graphics.fill({
-      texture:      block.texture,
-      matrix:       block.matrix,
-      color:        0xffffff,
-      alpha:        1.0,
-      textureSpace: 'global'
-    })
-
-  # Animated blocks use a Mesh so we can swap textures without rebuilding geometry.
+  # Every block (static or animated) is rendered as a Mesh. Animated blocks
+  # later swap mesh.texture between frame textures; static blocks just keep
+  # their single texture.
+  #
   # UV per world unit = scale * 0.25, matching xmoto C++
   # (src/xmscene/Block.cpp: texturePos = world * scale * 0.25). Combined with
   # the source's 'repeat' wrap, the texture tiles every 4 world units at
   # scale=1, independently of texture pixel size.
-  build_animated_mesh: (block) ->
-    uv_scale =  0.25 * block.usetexture.scale
+  build_mesh: (block) ->
+    uv_scale = 0.25 * block.usetexture.scale
 
     positions = new Float32Array(block.points.length * 2)
     uvs       = new Float32Array(block.points.length * 2)
@@ -186,7 +162,7 @@ class Blocks
 
     new PIXI.Mesh({
       geometry: geometry
-      texture:  block.frame_textures[0]
+      texture:  block.textures[0]
     })
 
   # One Graphic is created in each block layer (parallax or static)
@@ -227,7 +203,7 @@ class Blocks
 
     if frame != block.current_frame
       block.current_frame = frame
-      block.graphics.texture = block.frame_textures[frame]
+      block.graphics.texture = block.textures[frame]
 
   draw_debug_culling: ->
     culling_debugs = Object.values(@culling_debug_graphics)

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -39,13 +39,10 @@ class Blocks
       texture_params = @assets.theme.texture_params(block.usetexture.id)
 
       if texture_params.frames_count > 0
-        block.animated     = true
-        block.frames_count = texture_params.frames_count
-        block.delay        = texture_params.delay
-        block.frame_names  = (@frame_name(texture_params, i) for i in [0..texture_params.frames_count - 1])
-        block.texture_name = block.frame_names[0]
+        block.frames_count  = texture_params.frames_count
+        block.delay         = texture_params.delay
+        block.texture_names = @texture_names(texture_params)
       else
-        block.animated     = false
         block.texture_name = texture_params.file
 
       xml_materials = $(xml_block).find('edges material')
@@ -87,8 +84,8 @@ class Blocks
 
   load_assets: ->
     for block in @list
-      if block.animated
-        @assets.textures.push(frame_name) for frame_name in block.frame_names
+      if block.frames_count > 0
+        @assets.textures.push(texture_name) for texture_name in block.texture_names
       else
         @assets.textures.push(block.texture_name)
 
@@ -116,8 +113,8 @@ class Blocks
         new PIXI.Point(v.absolute_x, -v.absolute_y)
       )
 
-      if block.animated
-        block.textures        = (PIXI.Texture.from(@assets.get_url(name)) for name in block.frame_names)
+      if block.frames_count
+        block.textures        = (PIXI.Texture.from(@assets.get_url(name)) for name in block.texture_names)
         block.current_frame   = 0
         block.animation_start = performance.now()
       else
@@ -195,7 +192,7 @@ class Blocks
         block.graphics.visible = @visible(block)
         block.edges_list.update()
 
-        if block.animated && block.graphics.visible
+        if block.frames_count > 0 && block.graphics.visible
           @update_animation(block, now)
 
     if Constants.debug_culling
@@ -251,8 +248,9 @@ class Blocks
 
     return aabb
 
-  frame_name: (texture_params, frame_number) ->
-    "#{texture_params.file_base}#{(frame_number/100.0).toFixed(2).toString().substring(2)}.#{texture_params.file_extension}"
+  texture_names: (texture_params) ->
+    for frame_i in [0..texture_params.frames_count - 1]
+      "#{texture_params.file_base}#{(frame_i/100.0).toFixed(2).toString().substring(2)}.#{texture_params.file_extension}"
 
   # Blocks drawing is sorted by textures:
   # http://wiki.xmoto.tuxfamily.org/index.php?title=Others_tips_to_make_levels#Parallax_layers

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -22,7 +22,7 @@ class Blocks
                         attr = $(xml_block).find('position').attr('layerid')
                         if attr? then parseInt(attr) else undefined # integer or undefined if no attribute
         usetexture:
-          id:         $(xml_block).find('usetexture').attr('id').toLowerCase()
+          id:         $(xml_block).find('usetexture').attr('id')
           scale:      parseFloat($(xml_block).find('usetexture').attr('scale')) || 1.0
         physics:
           grip:       parseFloat($(xml_block).find('physics').attr('grip'))
@@ -69,7 +69,7 @@ class Blocks
           y:          parseFloat($(xml_vertex).attr('y'))
           absolute_x: parseFloat($(xml_vertex).attr('x')) + block.position.x # absolutes positions are practical
           absolute_y: parseFloat($(xml_vertex).attr('y')) + block.position.y # for edges creation
-          edge:       $(xml_vertex).attr('edge').toLowerCase() if $(xml_vertex).attr('edge')
+          edge:       $(xml_vertex).attr('edge')
 
         block.vertices.push(vertex)
 

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -38,7 +38,7 @@ class Blocks
 
       texture_params = @assets.theme.texture_params(block.usetexture.id)
 
-      if texture_params.frames_count > 0
+      if texture_params.frames_count
         block.frames_count  = texture_params.frames_count
         block.delay         = texture_params.delay
         block.texture_names = @texture_names(texture_params)
@@ -84,7 +84,7 @@ class Blocks
 
   load_assets: ->
     for block in @list
-      if block.frames_count > 0
+      if block.frames_count
         @assets.textures.push(texture_name) for texture_name in block.texture_names
       else
         @assets.textures.push(block.texture_name)
@@ -107,41 +107,34 @@ class Blocks
         @level.physics.create_lines(block, 'ground', ground.density, ground.restitution, ground.friction)
 
   init_sprites: ->
+    now = performance.now()
+
     for block in @list
       # Build polygon in world PIXI coordinates (y inverted)
       block.points = block.vertices.map((v) ->
         new PIXI.Point(v.absolute_x, -v.absolute_y)
       )
 
+      # Load block texture(s)
       if block.frames_count
         block.textures        = (PIXI.Texture.from(@assets.get_url(name)) for name in block.texture_names)
         block.current_frame   = 0
-        block.animation_start = performance.now()
+        block.animation_start = now
+        texture.source.addressMode = 'repeat' for texture in block.textures
       else
-        block.textures = [PIXI.Texture.from(@assets.get_url(block.texture_name))]
-
-      # 'repeat' wrap lets UVs > 1 tile the texture across the polygon.
-      for texture in block.textures
-        texture.source.addressMode = 'repeat'
+        block.texture = PIXI.Texture.from(@assets.get_url(block.texture_name))
+        block.texture.source.addressMode = 'repeat'
 
       block.graphics       = @build_mesh(block)
       block.graphics.label = block.id
 
       @level.layers.layer_for_block(block).addChild(block.graphics)
 
-  # Every block (static or animated) is rendered as a Mesh. Animated blocks
-  # later swap mesh.texture between frame textures; static blocks just keep
-  # their single texture.
-  #
-  # UV per world unit = scale * 0.25 * (256 / source.width).
-  # xmoto C++ uses scale * 0.25 directly (src/xmscene/Block.cpp:
-  # texturePos = world * scale * 0.25), which assumes 256-pixel textures and
-  # stretches lower-resolution textures (e.g. 128px clouds/water). Anchoring
-  # on 256 keeps standard-size textures identical to xmoto while tiling
-  # smaller textures proportionally denser for consistent on-screen pixel
-  # density.
+  # Every block (static or animated) is rendered as a Mesh (faster!).
+  # Animated blocks swap mesh.texture between frame textures
   build_mesh: (block) ->
-    source   = block.textures[0].source
+    texture  = if block.frames_count then block.textures[0] else block.texture
+    source   = texture.source
     uv_scale = block.usetexture.scale * 64.0 / source.width
 
     positions = new Float32Array(block.points.length * 2)
@@ -153,7 +146,9 @@ class Blocks
       uvs[i * 2]           =  uv_scale * point.x
       uvs[i * 2 + 1]       = -uv_scale * point.y
 
-    indices = new Uint32Array(PIXI.earcut(positions))
+    indices = new Uint32Array(
+      PIXI.earcut(positions) # Polygon Triangulation
+    )
 
     geometry = new PIXI.MeshGeometry({
       positions: positions
@@ -163,7 +158,7 @@ class Blocks
 
     new PIXI.Mesh({
       geometry: geometry
-      texture:  block.textures[0]
+      texture:  texture
     })
 
   # One Graphic is created in each block layer (parallax or static)
@@ -192,7 +187,7 @@ class Blocks
         block.graphics.visible = @visible(block)
         block.edges_list.update()
 
-        if block.frames_count > 0 && block.graphics.visible
+        if block.frames_count && block.graphics.visible
           @update_animation(block, now)
 
     if Constants.debug_culling
@@ -203,7 +198,7 @@ class Blocks
     frame   = Math.floor(elapsed / block.delay) % block.frames_count
 
     if frame != block.current_frame
-      block.current_frame = frame
+      block.current_frame    = frame
       block.graphics.texture = block.textures[frame]
 
   draw_debug_culling: ->

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -35,7 +35,18 @@ class Blocks
       block.no_collision ||= block.position.islayer && block.position.layerid != undefined # layer with specific layerid  => no collision
 
       block.usetexture.id = 'dirt' if block.usetexture.id == 'default'
-      block.texture_name  = @assets.theme.texture_params(block.usetexture.id).file
+
+      texture_params = @assets.theme.texture_params(block.usetexture.id)
+
+      if texture_params.frames > 0
+        block.animated     = true
+        block.frames_count = texture_params.frames
+        block.delay        = texture_params.delay
+        block.frame_names  = (@frame_name(texture_params, i) for i in [0..texture_params.frames - 1])
+        block.texture_name = block.frame_names[0]
+      else
+        block.animated     = false
+        block.texture_name = texture_params.file
 
       xml_materials = $(xml_block).find('edges material')
       for xml_material in xml_materials
@@ -76,7 +87,11 @@ class Blocks
 
   load_assets: ->
     for block in @list
-      @assets.textures.push(block.texture_name)
+      if block.animated
+        @assets.textures.push(frame_name) for frame_name in block.frame_names
+      else
+        @assets.textures.push(block.texture_name)
+
       block.edges_list.load_assets()
 
   init: ->
@@ -97,32 +112,42 @@ class Blocks
   init_sprites: ->
     for block in @list
       # Build polygon in world PIXI coordinates (y inverted)
-      points = block.vertices.map((v) ->
+      block.points = block.vertices.map((v) ->
         new PIXI.Point(v.absolute_x, -v.absolute_y)
       )
 
-      # Load block texture
-      texture = PIXI.Texture.from(@assets.get_url(block.texture_name))
-
       # Not translating the matrix ensures texture continuity between blocks
-      matrix = new PIXI.Matrix()
-      matrix.scale(block.usetexture.scale / 60.0, -block.usetexture.scale / 60.0)
-      #matrix.translate(block.aabb.lowerBound.x, -block.aabb.upperBound.y)
+      block.matrix = new PIXI.Matrix()
+      block.matrix.scale(block.usetexture.scale / 60.0, -block.usetexture.scale / 60.0)
+      #block.matrix.translate(block.aabb.lowerBound.x, -block.aabb.upperBound.y)
+
+      if block.animated
+        block.frame_textures = (PIXI.Texture.from(@assets.get_url(name)) for name in block.frame_names)
+        block.current_frame  = 0
+        # Stagger the animation start so neighbouring blocks of the same texture
+        # don't tear: they all share the same wall-clock based frame index.
+        block.animation_start = performance.now()
+      else
+        block.texture = PIXI.Texture.from(@assets.get_url(block.texture_name))
 
       # Create graphics with texture and matrix
       block.graphics = new PIXI.Graphics()
       block.graphics.label = block.id
 
-      block.graphics.poly(points)
-      block.graphics.fill({
-        texture:      texture,
-        matrix:       matrix,
-        color:        0xffffff,
-        alpha:        1.0,
-        textureSpace: 'global'
-      })
+      @draw_block_fill(block, if block.animated then block.frame_textures[0] else block.texture)
 
       @level.layers.layer_for_block(block).addChild(block.graphics)
+
+  draw_block_fill: (block, texture) ->
+    block.graphics.clear()
+    block.graphics.poly(block.points)
+    block.graphics.fill({
+      texture:      texture,
+      matrix:       block.matrix,
+      color:        0xffffff,
+      alpha:        1.0,
+      textureSpace: 'global'
+    })
 
   # One Graphic is created in each block layer (parallax or static)
   # for drawing culling rectangles. It's because parallax layers
@@ -144,12 +169,25 @@ class Blocks
 
   update: ->
     if !Constants.debug_physics
+      now = performance.now()
+
       for block in @list
         block.graphics.visible = @visible(block)
         block.edges_list.update()
 
+        if block.animated && block.graphics.visible
+          @update_animation(block, now)
+
     if Constants.debug_culling
       @draw_debug_culling()
+
+  update_animation: (block, now) ->
+    elapsed = (now - block.animation_start) / 1000.0
+    frame   = Math.floor(elapsed / block.delay) % block.frames_count
+
+    if frame != block.current_frame
+      block.current_frame = frame
+      @draw_block_fill(block, block.frame_textures[frame])
 
   draw_debug_culling: ->
     culling_debugs = Object.values(@culling_debug_graphics)
@@ -192,6 +230,9 @@ class Blocks
     aabb.upperBound.Set(Math.max.apply(null, x_positions), Math.max.apply(null, y_positions))
 
     return aabb
+
+  frame_name: (texture_params, frame_number) ->
+    "#{texture_params.file_base}#{(frame_number/100.0).toFixed(2).toString().substring(2)}.#{texture_params.file_extension}"
 
   # Blocks drawing is sorted by textures:
   # http://wiki.xmoto.tuxfamily.org/index.php?title=Others_tips_to_make_levels#Parallax_layers

--- a/src/level_elements/blocks.coffee
+++ b/src/level_elements/blocks.coffee
@@ -38,11 +38,11 @@ class Blocks
 
       texture_params = @assets.theme.texture_params(block.usetexture.id)
 
-      if texture_params.frames > 0
+      if texture_params.frames_count > 0
         block.animated     = true
-        block.frames_count = texture_params.frames
+        block.frames_count = texture_params.frames_count
         block.delay        = texture_params.delay
-        block.frame_names  = (@frame_name(texture_params, i) for i in [0..texture_params.frames - 1])
+        block.frame_names  = (@frame_name(texture_params, i) for i in [0..texture_params.frames_count - 1])
         block.texture_name = block.frame_names[0]
       else
         block.animated     = false

--- a/src/level_elements/entities.coffee
+++ b/src/level_elements/entities.coffee
@@ -168,7 +168,7 @@ class Entities
         @init_sprite(entity, @level.layers.static_foreground)
 
   init_sprite: (entity, container) ->
-    if entity.frames_count > 0
+    if entity.frames_count
       textures = []
       for i in [0..entity.frames_count - 1]
         textures.push(PIXI.Texture.from(@assets.get_url(@frame_name(entity, i))))

--- a/src/level_elements/entities.coffee
+++ b/src/level_elements/entities.coffee
@@ -57,7 +57,7 @@ class Entities
           entity.file_base      = theme_sprite.file_base
           entity.file_extension = theme_sprite.file_extension
           entity.delay          = theme_sprite.delay
-          entity.frames         = theme_sprite.frames
+          entity.frames_count   = theme_sprite.frames_count
           entity.display        = true # if an entity has a texture, it needs to be displayed
 
           # Default theme values if not defined in XML
@@ -99,10 +99,10 @@ class Entities
   load_assets: ->
     for entity in @list
       if entity.display
-        if entity.frames == 0
+        if entity.frames_count == 0
           @assets.anims.push(entity.file)
         else
-          for i in [0..entity.frames-1]
+          for i in [0..entity.frames_count-1]
             @assets.anims.push(@frame_name(entity, i))
 
   init: ->
@@ -168,9 +168,9 @@ class Entities
         @init_sprite(entity, @level.layers.static_foreground)
 
   init_sprite: (entity, container) ->
-    if entity.frames > 0
+    if entity.frames_count > 0
       textures = []
-      for i in [0..entity.frames - 1]
+      for i in [0..entity.frames_count - 1]
         textures.push(PIXI.Texture.from(@assets.get_url(@frame_name(entity, i))))
 
       sprite = new PIXI.AnimatedSprite(textures)

--- a/src/level_elements/sky.coffee
+++ b/src/level_elements/sky.coffee
@@ -7,7 +7,7 @@ class Sky
 
   parse: (xml) ->
     xml_sky  = $(xml).find('level info sky')
-    @name    = xml_sky.text().toLowerCase()
+    @name    = xml_sky.text()
     @color_r = parseInt(xml_sky.attr('color_r'))
     @color_g = parseInt(xml_sky.attr('color_g'))
     @color_b = parseInt(xml_sky.attr('color_b'))

--- a/src/utils/theme.coffee
+++ b/src/utils/theme.coffee
@@ -20,9 +20,10 @@ class Theme
     xml_sprites = $(xml).find('sprite')
 
     for xml_sprite in xml_sprites
+      name = $(xml_sprite).attr('name').toLowerCase()
 
       if $(xml_sprite).attr('type') == 'Entity'
-        @sprites[$(xml_sprite).attr('name')] =
+        @sprites[name] =
           file:           $(xml_sprite).attr('file')
           file_base:      $(xml_sprite).attr('fileBase')
           file_extension: $(xml_sprite).attr('fileExtension')
@@ -36,33 +37,32 @@ class Theme
           delay:     parseFloat($(xml_sprite).attr('delay'))
 
       else if $(xml_sprite).attr('type') == 'EdgeEffect'
-        @edges[$(xml_sprite).attr('name').toLowerCase()] =
-          file:  $(xml_sprite).attr('file').toLowerCase()
+        @edges[name] =
+          file:  $(xml_sprite).attr('file')
           scale: parseFloat($(xml_sprite).attr('scale'))
           depth: parseFloat($(xml_sprite).attr('depth'))
 
       else if $(xml_sprite).attr('type') == 'Texture'
-        name     = $(xml_sprite).attr('name').toLowerCase()
         frames   = $(xml_sprite).find('frame').length
         existing = @textures[name]
 
-        # Some themes declare both an animated entry and a static fallback under
-        # the same name (for older xmoto versions). Always keep the animated one.
+        # The same texture sometimes exists as both animated an non-animated (like "Lava", "Water1", "Water2", ...)
+        # => Always keep the animated one
         if !existing || existing.frames == 0
           @textures[name] =
-            file:           if $(xml_sprite).attr('file') then $(xml_sprite).attr('file').toLowerCase() else ''
+            file:           $(xml_sprite).attr('file')
             file_base:      $(xml_sprite).attr('fileBase')
-            file_extension: $(xml_sprite).attr('fileExtension')?.toLowerCase()
+            file_extension: $(xml_sprite).attr('fileExtension')
             frames:         frames
             delay:          parseFloat($(xml_sprite).attr('delay'))
 
     @callback()
 
   sprite_params: (name) ->
-    @sprites[name]
+    @sprites[name.toLowerCase()]
 
   edge_params: (name) ->
-    @edges[name]
+    @edges[name.toLowerCase()]
 
   texture_params: (name) ->
-    @textures[name]
+    @textures[name.toLowerCase()]

--- a/src/utils/theme.coffee
+++ b/src/utils/theme.coffee
@@ -42,12 +42,19 @@ class Theme
           depth: parseFloat($(xml_sprite).attr('depth'))
 
       else if $(xml_sprite).attr('type') == 'Texture'
-        @textures[$(xml_sprite).attr('name').toLowerCase()] =
-          file:           if $(xml_sprite).attr('file') then $(xml_sprite).attr('file').toLowerCase() else ''
-          file_base:      $(xml_sprite).attr('fileBase')
-          file_extension: $(xml_sprite).attr('fileExtension')
-          frames:         $(xml_sprite).find('frame').length
-          delay:          parseFloat($(xml_sprite).attr('delay'))
+        name     = $(xml_sprite).attr('name').toLowerCase()
+        frames   = $(xml_sprite).find('frame').length
+        existing = @textures[name]
+
+        # Some themes declare both an animated entry and a static fallback under
+        # the same name (for older xmoto versions). Always keep the animated one.
+        if !existing || existing.frames == 0
+          @textures[name] =
+            file:           if $(xml_sprite).attr('file') then $(xml_sprite).attr('file').toLowerCase() else ''
+            file_base:      $(xml_sprite).attr('fileBase')
+            file_extension: $(xml_sprite).attr('fileExtension')?.toLowerCase()
+            frames:         frames
+            delay:          parseFloat($(xml_sprite).attr('delay'))
 
     @callback()
 

--- a/src/utils/theme.coffee
+++ b/src/utils/theme.coffee
@@ -28,13 +28,13 @@ class Theme
           file_base:      $(xml_sprite).attr('fileBase')
           file_extension: $(xml_sprite).attr('fileExtension')
           size:
-            width:   parseFloat($(xml_sprite).attr('width'))
-            height:  parseFloat($(xml_sprite).attr('height'))
+            width:  parseFloat($(xml_sprite).attr('width'))
+            height: parseFloat($(xml_sprite).attr('height'))
           center:
-            x:       parseFloat($(xml_sprite).attr('centerX'))
-            y:       parseFloat($(xml_sprite).attr('centerY'))
-          frames:    $(xml_sprite).find('frame').length
-          delay:     parseFloat($(xml_sprite).attr('delay'))
+            x: parseFloat($(xml_sprite).attr('centerX'))
+            y: parseFloat($(xml_sprite).attr('centerY'))
+          frames_count: $(xml_sprite).find('frame').length
+          delay: parseFloat($(xml_sprite).attr('delay'))
 
       else if $(xml_sprite).attr('type') == 'EdgeEffect'
         @edges[name] =
@@ -43,17 +43,14 @@ class Theme
           depth: parseFloat($(xml_sprite).attr('depth'))
 
       else if $(xml_sprite).attr('type') == 'Texture'
-        frames   = $(xml_sprite).find('frame').length
-        existing = @textures[name]
-
         # The same texture sometimes exists as both animated an non-animated (like "Lava", "Water1", "Water2", ...)
         # => Always keep the animated one
-        if !existing || existing.frames == 0
+        if !@textures[name] || @textures[name].frames_count == 0
           @textures[name] =
             file:           $(xml_sprite).attr('file')
             file_base:      $(xml_sprite).attr('fileBase')
             file_extension: $(xml_sprite).attr('fileExtension')
-            frames:         frames
+            frames_count:   $(xml_sprite).find('frame').length
             delay:          parseFloat($(xml_sprite).attr('delay'))
 
     @callback()


### PR DESCRIPTION
## What has been changed?

 * Animated textures for blocks using Mesh (better GPU performance!)
 * Improve texture scale.
 * Improve theme loading (lowercase management)

## Results

Now the texture and blocks are almost completely identical:

JS left / C right

<img width="2050" height="769" alt="Screenshot 2026-06-16 at 17 50 54" src="https://github.com/user-attachments/assets/845ab0e0-74d5-40d0-92fd-71d9662f93da" />